### PR TITLE
Override default style classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,10 @@ style:
   placeholder_terminal_bg_color: '#1a1b26'
   #character used to indicate the current selection
   pointer_char: '&#9654;'
+  #override default style classes
+  #https://github.com/prompt-toolkit/python-prompt-toolkit/blob/master/src/prompt_toolkit/styles/defaults.py
+  style_classes:
+    cursor-line: 'underline'
 keybinding:
   # a map of app actions to their respective key bindings.
   # each key combo in an action list is an alias for the same action.

--- a/app/config.py
+++ b/app/config.py
@@ -53,6 +53,7 @@ class StyleConfig:
     status_stopped_color: str = 'ansired'
     placeholder_terminal_bg_color: str = '#1a1b26'
     pointer_char: str = '&#9654;'
+    style_classes: Optional[Dict[str, str]] = None
 
 
 @dataclass

--- a/app/tui/app.py
+++ b/app/tui/app.py
@@ -6,6 +6,7 @@ from prompt_toolkit.application import Application
 from prompt_toolkit.key_binding import KeyBindings
 from prompt_toolkit.layout import ConditionalContainer, DynamicContainer, HSplit, Layout, VSplit, Window
 from prompt_toolkit.layout.dimension import D
+from prompt_toolkit.styles import Style
 from prompt_toolkit.widgets import Frame
 from ptterm import Terminal
 
@@ -143,6 +144,7 @@ def start_tui():
         key_bindings=kb,
         full_screen=True,
         mouse_support=False,
+        style=Style(list((ctx.config.style.style_classes or {}).items()))
     )
 
     def refresh_app():


### PR DESCRIPTION
Add a configuration option that allows users to override default style classes.

Examples with different configurations:

```yaml
style:
  style_classes:
    cursor-line: 'nounderline'
```
![Screen Shot 2022-09-27 at 9 30 54 PM](https://user-images.githubusercontent.com/34012432/192667000-5f929af8-582a-4606-84c1-65de6ecff746.png)

```yaml
style:
  style_classes:
    cursor-line: 'nounderline reverse'
```
![Screen Shot 2022-09-27 at 9 31 06 PM](https://user-images.githubusercontent.com/34012432/192667011-d3062f07-962d-40de-bbb2-61001eb507f1.png)

With style_classes absent from config:
![Screen Shot 2022-09-27 at 9 31 16 PM](https://user-images.githubusercontent.com/34012432/192667017-68721f91-d6db-4cfc-b806-7ee6d7ee08de.png)
