### PR TITLE
custom pointer char

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ style:
   status_stopped_color: 'ansired'
   #the color of the right panel (terminal panel) when no terminal is created/selected yet
   placeholder_terminal_bg_color: '#1a1b26'
+  #character used to indicate the current selection
+  pointer_char: '&#9654;'
 keybinding:
   # a map of app actions to their respective key bindings.
   # each key combo in an action list is an alias for the same action.

--- a/app/config.py
+++ b/app/config.py
@@ -52,6 +52,7 @@ class StyleConfig:
     status_running_color: str = 'ansigreen'
     status_stopped_color: str = 'ansired'
     placeholder_terminal_bg_color: str = '#1a1b26'
+    pointer_char: str = '&#9654;'
 
 
 @dataclass

--- a/app/tui/side_bar.py
+++ b/app/tui/side_bar.py
@@ -121,7 +121,7 @@ class SideBar:
                 result.append([("[SetCursorPosition]", "")])
                 bg_color = f'bg="{ctx.config.style.selected_process_bg_color}"'
                 fg_color = f'fg="{ctx.config.style.selected_process_color}"'
-                pointer_char = "&#9654;"
+                pointer_char = ctx.config.style.pointer_char
             result.append(
                 HTML(f'<style {fg_color} {bg_color}>'
                      f'<bold>{pointer_char}{name_fixed}</bold></style>'


### PR DESCRIPTION
Add configuration option to allow user to customize the current selection pointer character.

Add a configuration option that allows users to override default style classes.

Examples with different configurations:

```yaml
style:
  pointer_char: '&#9679'
```
![Screen Shot 2022-09-27 at 9 42 58 PM](https://user-images.githubusercontent.com/34012432/192668720-a235774c-6d10-420e-91ea-3fb76c7ac400.png)

```yaml
style:
  pointer_char: 'X'
```
![Screen Shot 2022-09-27 at 9 43 16 PM](https://user-images.githubusercontent.com/34012432/192668726-617bdb53-4cf3-4ae8-819b-878cf0a7f0e3.png)

With pointer_char absent from config:
![Screen Shot 2022-09-27 at 9 43 30 PM](https://user-images.githubusercontent.com/34012432/192668730-097fa4e7-fe5c-4b22-aa6b-93ab870621bc.png)
