### PR TITLE
focus sidebar on zoom out

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,8 @@ keybinding:
     - 'c-w'
   zoom:
     - 'z'
+  toggle_scroll:
+    - 'u'
 shell_cmd:
   # this is the command used for all 'procs' that are defined with a 'shell' property.
   # by default the configured "$SHELL" environment variable will be used.

--- a/app/config.py
+++ b/app/config.py
@@ -65,6 +65,7 @@ class KeybindingConfig:
     down: List[str] = field(default_factory=lambda: ['down', 'j'])
     switch_focus: List[str] = field(default_factory=lambda: ['c-w'])
     zoom: List[str] = field(default_factory=lambda: ['z'])
+    toggle_scroll: List[str] = field(default_factory=lambda: ['u'])
 
     def __post_init__(self):
         for keybinding_field in fields(KeybindingConfig):

--- a/app/exec.py
+++ b/app/exec.py
@@ -22,6 +22,7 @@ class TerminalManager:
         self._proc_name = process_name
         self._terminal: Terminal = None
         self._running = False
+        self._scroll_mode = False
         self._on_done_callbacks = []
         if on_done:
             self._on_done_callbacks = [on_done]
@@ -125,3 +126,12 @@ class TerminalManager:
             self.spawn_terminal()
             return True
         return False
+
+    def toggle_scroll_mode(self) -> bool:
+        if self._scroll_mode:
+            self._terminal.exit_copy_mode()
+            self._scroll_mode = False
+        else:
+            self._terminal.enter_copy_mode()
+            self._scroll_mode = True
+        return self._scroll_mode

--- a/app/tui/app.py
+++ b/app/tui/app.py
@@ -70,6 +70,11 @@ def start_tui():
     def _handle_quit():
         application.exit()
 
+    def _handle_toggle_scroll(proc_idx: int):
+        scroll_mode_on = ctx.tui_state.terminal_managers[proc_idx].toggle_scroll_mode()
+        if not scroll_mode_on:
+            focus_manager.focus_to_sidebar()
+
     terminal_placeholder = Window(style=f'bg:{ctx.config.style.placeholder_terminal_bg_color}',
                                   width=_width_100,
                                   height=_height_100)
@@ -107,6 +112,12 @@ def start_tui():
         def _zoom(_event):
             logger.info('in _zoom')
             focus_manager.toggle_zoom()
+
+    for keybinding in ctx.config.keybinding.toggle_scroll:
+        @kb.add(keybinding)
+        def _toggle_scroll(_event) -> None:
+            logger.info('in _toggle_scroll')
+            _handle_toggle_scroll(ctx.tui_state.selected_process_idx)
 
     main_layout_container = HSplit([
         VSplit([

--- a/app/tui/focus.py
+++ b/app/tui/focus.py
@@ -39,6 +39,7 @@ class FocusManager:
         if zoomed_in:
             logger.info('setting zoomed_in to False')
             self._ctx.tui_state.zoomed_in = False
+            self.focus_to_sidebar()
         else:
             success = self.focus_to_terminal()
             if success:
@@ -65,13 +66,16 @@ class FocusManager:
                         'toggling zoom off instead')
             self.toggle_zoom()
             return
-        application = get_app()
         idx = self._ctx.tui_state.selected_process_idx
         current_focus = self.get_focused_widget()
         if current_focus == FocusWidget.TERMINAL:
-            logger.info('focusing on sidebar')
-            side_bar = self.get_element_by_focus_widget(FocusWidget.SIDE_BAR_SELECT)
-            if side_bar:
-                application.layout.focus(side_bar)
+            self.focus_to_sidebar()
         elif current_focus == FocusWidget.SIDE_BAR_SELECT and idx is not None:
             self.focus_to_terminal()
+
+    def focus_to_sidebar(self):
+        logger.info('focusing on sidebar')
+        side_bar = self.get_element_by_focus_widget(FocusWidget.SIDE_BAR_SELECT)
+        if side_bar:
+            application = get_app()
+            application.layout.focus(side_bar)

--- a/app/tui/help.py
+++ b/app/tui/help.py
@@ -44,12 +44,16 @@ class HelpPanel:
             result.append(self._get_key_combo_text(key_config.switch_focus, 'switch focus'))
             result.append(delimiter)
             result.append(self._get_key_combo_text(key_config.zoom, 'zoom'))
+            result.append(delimiter)
+            result.append(self._get_key_combo_text(key_config.toggle_scroll, 'toggle scroll'))
         elif self._focus_manager.get_focused_widget() == FocusWidget.SIDE_BAR_FILTER:
             result.append(self._get_key_combo_text(key_config.submit_filter, 'filter'))
         else:
             result.append(self._get_key_combo_text(key_config.switch_focus, 'switch focus'))
             result.append(delimiter)
             result.append(self._get_key_combo_text(key_config.zoom, 'zoom'))
+            result.append(delimiter)
+            result.append(self._get_key_combo_text(key_config.toggle_scroll, 'toggle scroll'))
         return merge_formatted_text(result)
 
     def _get_key_combo_text(self, key_combos: List[str], label: str):


### PR DESCRIPTION
Set focus back to sidebar after zooming out.

Demo shows behavior when pressing ctrl + w to toggle focus between sidebar/terminal, pressing z to toggle focus, and pressing z to zoom, then ctrl + w to switch focus back to the sidebar.


https://user-images.githubusercontent.com/34012432/192677616-2160a5fc-f47d-4f9b-be0b-64fc2460d704.mov