### PR TITLE
improve help context awareness

### DIFF
--- a/app/exec.py
+++ b/app/exec.py
@@ -95,6 +95,12 @@ class TerminalManager:
         for handler in self._on_done_callbacks:
             handler()
 
+    def _handle_process_spawned(self):
+        logger.info(f'created terminal {self._terminal}')
+        self._running = True
+        for handler in self._on_spawn_callbacks:
+            handler()
+
     def spawn_terminal(self):
         if self.is_running():
             logger.info(f'spawned - returning existing terminal - {self._terminal}')
@@ -106,8 +112,7 @@ class TerminalManager:
             self._adjust_path()
 
         self._terminal = self._term_ctor(self.get_cmd(), before_exec, self._handle_process_done)
-        logger.info(f'created terminal {self._terminal}')
-        self._running = True
+        self._handle_process_spawned()
         return self._terminal
 
     def get_terminal(self):

--- a/app/tui/help.py
+++ b/app/tui/help.py
@@ -31,22 +31,27 @@ class HelpPanel:
         result = []
         delimiter = " | "
         key_config = self._ctx.config.keybinding
+        selected_process_running = self._ctx.tui_state.is_selected_process_running
+        selected_process_has_terminal = self._ctx.tui_state.selected_process_has_terminal
         if self._focus_manager.get_focused_widget() == FocusWidget.SIDE_BAR_SELECT:
             result.append(self._get_key_combo_text(key_config.up, 'up'))
             result.append(delimiter)
             result.append(self._get_key_combo_text(key_config.down, 'down'))
-            result.append(delimiter)
-            result.append(self._get_key_combo_text(key_config.start, 'start'))
-            result.append(delimiter)
-            result.append(self._get_key_combo_text(key_config.stop, 'stop'))
+            if not selected_process_running:
+                result.append(delimiter)
+                result.append(self._get_key_combo_text(key_config.start, 'start'))
+            if selected_process_running:
+                result.append(delimiter)
+                result.append(self._get_key_combo_text(key_config.stop, 'stop'))
             result.append(delimiter)
             result.append(self._get_key_combo_text(key_config.quit, 'quit'))
-            result.append(delimiter)
-            result.append(self._get_key_combo_text(key_config.switch_focus, 'switch focus'))
-            result.append(delimiter)
-            result.append(self._get_key_combo_text(key_config.zoom, 'zoom'))
-            result.append(delimiter)
-            result.append(self._get_key_combo_text(key_config.toggle_scroll, 'toggle scroll'))
+            if selected_process_has_terminal:
+                result.append(delimiter)
+                result.append(self._get_key_combo_text(key_config.switch_focus, 'switch focus'))
+                result.append(delimiter)
+                result.append(self._get_key_combo_text(key_config.zoom, 'zoom'))
+                result.append(delimiter)
+                result.append(self._get_key_combo_text(key_config.toggle_scroll, 'toggle scroll'))
         elif self._focus_manager.get_focused_widget() == FocusWidget.SIDE_BAR_FILTER:
             result.append(self._get_key_combo_text(key_config.submit_filter, 'filter'))
         elif self._focus_manager.get_focused_widget() == FocusWidget.DOCS:

--- a/app/tui_state.py
+++ b/app/tui_state.py
@@ -21,6 +21,23 @@ class TUIState:
     zoomed_in: bool = False
     docs_open: bool = False
 
+    @property
+    def selected_process_terminal_manager(self) -> Optional[TerminalManager]:
+        if self.selected_process_idx:
+            return self.terminal_managers[self.selected_process_idx]
+        return None
+
+    @property
+    def is_selected_process_running(self) -> bool:
+        return self.selected_process_terminal_manager.is_running() \
+            if self.selected_process_terminal_manager else False
+
+    @property
+    def selected_process_has_terminal(self) -> bool:
+        return \
+            self.selected_process_terminal_manager.get_terminal() is not None \
+            if self.selected_process_terminal_manager else False
+
     def get_process_index_by_name(self, proc_name):
         if not self._process_name_to_idx:
             self._process_name_to_idx = {name: idx for idx, name in enumerate(self.process_name_list)}

--- a/app/tui_state.py
+++ b/app/tui_state.py
@@ -23,7 +23,7 @@ class TUIState:
 
     @property
     def selected_process_terminal_manager(self) -> Optional[TerminalManager]:
-        if self.selected_process_idx:
+        if self.selected_process_idx is not None and self.selected_process_idx > -1:
             return self.terminal_managers[self.selected_process_idx]
         return None
 

--- a/test/test_tui.py
+++ b/test/test_tui.py
@@ -91,8 +91,8 @@ def test_tui_shows_process_list_help():
     def assert_process_list_help_bar(screen):
         full_screen = join_screen_to_str(screen)
         assert '<s> start' in full_screen
-        assert '<x> stop' in full_screen
-        assert '<w> switch' in full_screen
+        assert '<x> stop' not in full_screen
+        assert '<q> quit' in full_screen
 
     preform_test_within_tui(keys=[], assertion=assert_process_list_help_bar)
 


### PR DESCRIPTION
Increase context awareness of help bar. Intelligently display available commands based on whether or not the current process is running, and if it has a terminal available.

~PR has a bug which should be resolved before merging. The terminal manager associated with the first process in the list always returns None from get_terminal.~

~This PR also breaks tests, will update the tests~ ~after the bug has been fixed~ ~soon~.

This PR leaves one test broken, that was likely broken by the PR to add scroll mode. Will open another PR to address.