### PR TITLE
modifiers on app level key bindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,9 +105,9 @@ keybinding:
   switch_focus:
     - 'c-w'
   zoom:
-    - 'z'
+    - 'c-z'
   toggle_scroll:
-    - 'u'
+    - 'c-s'
 shell_cmd:
   # this is the command used for all 'procs' that are defined with a 'shell' property.
   # by default the configured "$SHELL" environment variable will be used.

--- a/app/config.py
+++ b/app/config.py
@@ -67,9 +67,9 @@ class KeybindingConfig:
     up: List[str] = field(default_factory=lambda: ['up', 'k'])
     down: List[str] = field(default_factory=lambda: ['down', 'j'])
     switch_focus: List[str] = field(default_factory=lambda: ['c-w'])
-    zoom: List[str] = field(default_factory=lambda: ['z'])
+    zoom: List[str] = field(default_factory=lambda: ['c-z'])
     docs: List[str] = field(default_factory=lambda: ['?'])
-    toggle_scroll: List[str] = field(default_factory=lambda: ['u'])
+    toggle_scroll: List[str] = field(default_factory=lambda: ['c-s'])
 
     def __post_init__(self):
         for keybinding_field in fields(KeybindingConfig):

--- a/procmux.yaml
+++ b/procmux.yaml
@@ -20,6 +20,12 @@ style:
   status_stopped_color:  'ansired'
   #the color of the right panel (terminal panel) when no terminal is created/selected yet
   placeholder_terminal_bg_color: '#1a1b26'
+  #character used to indicate the current selection
+  pointer_char: '&#9654;'
+  #override default style classes
+  #https://github.com/prompt-toolkit/python-prompt-toolkit/blob/master/src/prompt_toolkit/styles/defaults.py
+  style_classes:
+    cursor-line: 'underline'
 keybinding:
   # a map of app actions to their respective key bindings.
   # each key combo in an action list is an alias for the same action.
@@ -44,7 +50,9 @@ keybinding:
   switch_focus:
     - 'c-w'
   zoom:
-    - 'z'
+    - 'c-z'
+  toggle_scroll:
+    - 'c-s'
 shell_cmd:
   # this is the command used for all 'procs' that are defined with a 'shell' property.
   # by default the configured "$SHELL" environment variable will be used.


### PR DESCRIPTION
All app level bindings should have a modifier on them. This is to prevent them from interfering with any process/action that requires the user to input some value(s) by typing.

Fixes tests broken by previous PRs.