### PR TITLE
select first process after filtering

### DIFF
--- a/app/tui/side_bar.py
+++ b/app/tui/side_bar.py
@@ -137,7 +137,12 @@ class SideBar:
             @kb.add(keybinding)
             def _exit_filter(_event) -> None:
                 logger.info('in _exit_filter')
-                self._ctx.tui_state.selected_process_idx = -1
+                filtered_list = self._get_filtered_process_name_list()
+                if filtered_list:
+                    self._ctx.tui_state.selected_process_idx = \
+                        self._ctx.tui_state.get_process_index_by_name(filtered_list[0])
+                else:
+                    self._ctx.tui_state.selected_process_idx = -1
                 self._focus_manager.set_focus(self._list_control)
                 self._filter_mode = False
         return kb


### PR DESCRIPTION
Automatically set the selected process index to the first item in the filtered list after filtering. If there are no items in the filtered process list, set the selected process index to -1, as is consistent with the previous behavior.