### PR TITLE
color levels

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,8 @@ style:
   #https://github.com/prompt-toolkit/python-prompt-toolkit/blob/master/src/prompt_toolkit/styles/defaults.py
   style_classes:
     cursor-line: 'underline'
+  #one of: monochrome | ansicolors | 256colors | truecolors
+  color_level: 'truecolors'
 keybinding:
   # a map of app actions to their respective key bindings.
   # each key combo in an action list is an alias for the same action.

--- a/app/config.py
+++ b/app/config.py
@@ -1,7 +1,9 @@
 import hiyapyco
 from dataclasses import dataclass, field, fields
 import os
-from typing import Dict, List, Optional, OrderedDict, Union
+from typing import Dict, List, Literal, Optional, OrderedDict, Union
+
+from prompt_toolkit.output import ColorDepth
 
 
 class MisconfigurationError(Exception):
@@ -55,6 +57,20 @@ class StyleConfig:
     placeholder_terminal_bg_color: str = '#1a1b26'
     pointer_char: str = '&#9654;'
     style_classes: Optional[Dict[str, str]] = None
+    color_level: \
+        Optional[Literal['monochrome'] | Literal['ansicolors'] | Literal['256colors'] | Literal['truecolors']] = None
+
+    @property
+    def color_depth(
+            self
+    ) -> Literal['DEPTH_1_BIT'] | Literal['DEPTH_4_BIT'] | Literal['DEPTH_8_BIT'] | Literal['DEPTH_24_BIT']:
+        if self.color_level == 'monochrome':
+            return ColorDepth.MONOCHROME
+        if self.color_level == 'ansicolors':
+            return ColorDepth.ANSI_COLORS_ONLY
+        if self.color_level == '256colors':
+            return ColorDepth.DEFAULT
+        return ColorDepth.TRUE_COLOR
 
 
 @dataclass

--- a/app/tui/app.py
+++ b/app/tui/app.py
@@ -154,7 +154,8 @@ def start_tui():
         key_bindings=kb,
         full_screen=True,
         mouse_support=False,
-        style=Style(list((ctx.config.style.style_classes or {}).items()))
+        style=Style(list((ctx.config.style.style_classes or {}).items())),
+        color_depth=ctx.config.style.color_depth
     )
 
     def refresh_app():

--- a/procmux.yaml
+++ b/procmux.yaml
@@ -26,6 +26,8 @@ style:
   #https://github.com/prompt-toolkit/python-prompt-toolkit/blob/master/src/prompt_toolkit/styles/defaults.py
   style_classes:
     cursor-line: 'underline'
+  #one of: monochrome | ansicolors | 256colors | truecolors
+  color_level: 'truecolors'
 keybinding:
   # a map of app actions to their respective key bindings.
   # each key combo in an action list is an alias for the same action.


### PR DESCRIPTION
Add configuration option to allow user to select the color level.

# Important Consideration
This pull request changes the default color depth from 8 bit to 24 bit.

## screenshots
True colors:
![Screen Shot 2022-09-29 at 4 46 15 PM](https://user-images.githubusercontent.com/34012432/193146035-78ec678b-d51b-4ae3-87b8-898772fabb37.png)

256 colors:
![Screen Shot 2022-09-29 at 4 46 00 PM](https://user-images.githubusercontent.com/34012432/193146038-aba654d3-1654-4a60-972c-aaec43baf0b3.png)

Ansi colors:
![Screen Shot 2022-09-29 at 4 45 41 PM](https://user-images.githubusercontent.com/34012432/193146039-53352911-fdc0-4131-8699-eeb7c9bff490.png)

Monochrome:
![Screen Shot 2022-09-29 at 4 45 22 PM](https://user-images.githubusercontent.com/34012432/193146040-324f269e-b5c0-4580-b390-eba68440a267.png)