### PR TITLE
wait for processes to stop before quitting

### DIFF
--- a/app/tui/help.py
+++ b/app/tui/help.py
@@ -37,7 +37,7 @@ class HelpPanel:
             result.append(self._get_key_combo_text(key_config.up, 'up'))
             result.append(delimiter)
             result.append(self._get_key_combo_text(key_config.down, 'down'))
-            if not selected_process_running:
+            if not selected_process_running and not self._ctx.tui_state.quitting:
                 result.append(delimiter)
                 result.append(self._get_key_combo_text(key_config.start, 'start'))
             if selected_process_running:

--- a/app/tui/side_bar.py
+++ b/app/tui/side_bar.py
@@ -205,6 +205,8 @@ class SideBar:
             @kb.add(keybinding)
             def _quit(_event) -> None:
                 logger.info('in _quit')
+                if self._ctx.tui_state.quitting:
+                    return
                 for m in self._ctx.tui_state.terminal_managers:
                     m.send_kill_signal()
                 if self._on_quit:

--- a/app/tui_state.py
+++ b/app/tui_state.py
@@ -20,6 +20,7 @@ class TUIState:
     terminal_managers: List[TerminalManager] = field(default_factory=lambda: [])
     zoomed_in: bool = False
     docs_open: bool = False
+    quitting: bool = False
 
     @property
     def selected_process_terminal_manager(self) -> Optional[TerminalManager]:
@@ -37,6 +38,13 @@ class TUIState:
         return \
             self.selected_process_terminal_manager.get_terminal() is not None \
             if self.selected_process_terminal_manager else False
+
+    @property
+    def has_running_processes(self) -> bool:
+        for tm in self.terminal_managers:
+            if tm.is_running():
+                return True
+        return False
 
     def get_process_index_by_name(self, proc_name):
         if not self._process_name_to_idx:


### PR DESCRIPTION
Wait for processes to stop before quitting. Prevent startup of processes once quit is invoked. Remove start from help menu when quitting.


https://user-images.githubusercontent.com/34012432/193148086-2977d70a-8ac1-42df-8dae-9595d668b857.mov