### PR TITLE
add should_show for app wide keybindings

### DIFF
--- a/app/tui/keybindings.py
+++ b/app/tui/keybindings.py
@@ -61,20 +61,25 @@ def register_app_wide_configured_keybindings(config: ProcMuxConfig,
                                              switch_focus: Callable[[], None],
                                              zoom: Callable[[], None],
                                              toggle_scroll: Callable[[], None],
-                                             kb: DocumentedKeybindings) -> DocumentedKeybindings:
+                                             kb: DocumentedKeybindings,
+                                             should_show_help: Optional[Callable[[], bool]] = None
+                                             ) -> DocumentedKeybindings:
     kb = register_configured_keybinding_no_event(
         config.keybinding.switch_focus,
         switch_focus,
         kb,
-        help_label='switch_focus')
+        help_label='switch_focus',
+        should_show_help=should_show_help)
     kb = register_configured_keybinding_no_event(
         config.keybinding.zoom,
         zoom,
         kb,
-        help_label='zoom')
+        help_label='zoom',
+        should_show_help=should_show_help)
     kb = register_configured_keybinding_no_event(
         config.keybinding.toggle_scroll,
         toggle_scroll,
         kb,
-        help_label='toggle scroll')
+        help_label='toggle scroll',
+        should_show_help=should_show_help)
     return kb

--- a/app/tui/view/side_bar.py
+++ b/app/tui/view/side_bar.py
@@ -7,6 +7,7 @@ from prompt_toolkit.layout import DynamicContainer, HSplit, ScrollbarMargin, Win
 from prompt_toolkit.layout.controls import BufferControl, FormattedTextControl
 from prompt_toolkit.layout.dimension import D, Dimension
 from prompt_toolkit.widgets import Frame
+from ptterm import Terminal
 
 from app.tui.keybindings import DocumentedKeybindings, register_app_wide_configured_keybindings, \
     register_configured_keybinding_no_event
@@ -155,11 +156,16 @@ class SideBar:
                                                      self._controller.view_docs,
                                                      kb,
                                                      'docs')
+
+        def has_terminal() -> bool:
+            return isinstance(self._controller.current_terminal, Terminal)
         kb = register_app_wide_configured_keybindings(self._controller.config,
                                                       self._controller.switch_focus,
                                                       self._controller.zoom,
                                                       self._controller.toggle_scroll,
-                                                      kb)
+                                                      kb,
+                                                      has_terminal
+                                                      )
         return kb
 
     def __pt_container__(self):


### PR DESCRIPTION
Only show app wide keybindings when a terminal is present.