### PR TITLE
config default files

### DIFF
--- a/app/args.py
+++ b/app/args.py
@@ -1,6 +1,23 @@
 import argparse
 
+import os
+
 parser = argparse.ArgumentParser(description="procmux-tui")
-parser.add_argument('--config', required=True)
+parser.add_argument('--config', required=False)
 parser.add_argument('--config-override', required=False)
 cli_args = parser.parse_args()
+if not cli_args.config:
+    potential_defaults = [
+            'procmux-config.yml', 
+            'procmux-config.yaml', 
+            'procmux.yml', 
+            'procmux.yaml'
+    ]
+    for potential_default in potential_defaults:
+        if os.path.exists(potential_default):
+            cli_args.config = potential_default 
+            break
+    if not cli_args.config:
+        raise RuntimeError(f"{', '.join(potential_defaults)}  config files were not found in the current directory, please use --config to pass a procmux configuration file.") 
+
+

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("requirements.txt", "r", encoding="utf-8") as fh:
     requirements = fh.read()
 setup(
     name='procmux',
-    version='1.0.9',
+    version='1.0.10',
     author='Nick Pisani',
     author_email='napisani@yahoo.com',
     license='MIT',


### PR DESCRIPTION
This pr allows the user to call 'procmux' without passing --config. 

if --config is not defined, a series of procmux config combinations are searched for in the current working directory. 
The first one found is used